### PR TITLE
Add French translation for error handling

### DIFF
--- a/busted/languages/fr.lua
+++ b/busted/languages/fr.lua
@@ -21,6 +21,8 @@ s:set('output.success_single', 'reussite')
 
 s:set('output.seconds', 'secondes')
 
+s:set('output.no_test_files_match', 'Aucun test n\'est pourrait trouvé qui corresponde au motif de Lua: %s')
+
 -- definitions following are not used within the 'say' namespace
 return {
   failure_messages = {


### PR DESCRIPTION
I must admit, it's a very rough translation - French is not my primary language (I have been taking classes for 5 years now) but it should be understandable to a French speaker.

The phrase translates literally to "No test could be found which corresponds to the pattern of Lua: %s".
